### PR TITLE
Fix: Going to the Settings panel before the parent panel in addon settings no longer causes the latter not to update

### DIFF
--- a/AutomaticRoleCheck.lua
+++ b/AutomaticRoleCheck.lua
@@ -21,6 +21,8 @@ AutomaticRoleCheck.EventHandler = function(self, event, arg, ...)
         AutomaticRoleCheck.Options[k] = v
       end
     end
+    AutomaticRoleCheck.Panel.PopulatePanel()
+    AutomaticRoleCheck.Panel.Settings.PopulatePanel()
   elseif event == "PLAYER_LOGOUT" then
     AutomaticRoleCheck_Options = AutomaticRoleCheck.Options
   end

--- a/AutomaticRoleCheck_Panel.lua
+++ b/AutomaticRoleCheck_Panel.lua
@@ -3,25 +3,31 @@ AutomaticRoleCheck.Panel:RegisterEvent("ADDON_LOADED")
 AutomaticRoleCheck.Panel:RegisterEvent("PLAYER_LOGOUT")
 AutomaticRoleCheck.Panel.name = "AutomaticRoleCheck"
 
-AutomaticRoleCheck.Panel.Inner = AutomaticRoleCheck.Panel:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
-AutomaticRoleCheck.Panel.Inner:SetPoint("TOPLEFT", 10, -15)
-AutomaticRoleCheck.Panel.Inner:SetJustifyH("LEFT")
-AutomaticRoleCheck.Panel.Inner:SetJustifyV("TOP")
-AutomaticRoleCheck.Panel.Inner:SetText("AutomaticRoleCheck")
+AutomaticRoleCheck.Panel.General = CreateFrame("Frame", nil, AutomaticRoleCheck.Panel)
 
-AutomaticRoleCheck.Panel.Inner.EnabledButton = CreateFrame("CheckButton", nil, AutomaticRoleCheck.Panel, "ChatConfigCheckButtonTemplate")
-AutomaticRoleCheck.Panel.Inner.EnabledButton:SetPoint("TOPLEFT", 10, -45)
-AutomaticRoleCheck.Panel.Inner.EnabledButton.Text:SetFontObject("GameFontHighlightSmall")
-AutomaticRoleCheck.Panel.Inner.EnabledButton.Text:SetPoint("LEFT", AutomaticRoleCheck.Panel.Inner.EnabledButton, "RIGHT", 0, 1)
-AutomaticRoleCheck.Panel.Inner.EnabledButton.Text:SetText("Enable AutomaticRoleCheck")
-AutomaticRoleCheck.Panel.Inner.EnabledButton.tooltip = "If the AutomaticRoleCheck addon is enabled."
+AutomaticRoleCheck.Panel.General.Inner = AutomaticRoleCheck.Panel:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
+AutomaticRoleCheck.Panel.General.Inner:SetPoint("TOPLEFT", 10, -15)
+AutomaticRoleCheck.Panel.General.Inner:SetJustifyH("LEFT")
+AutomaticRoleCheck.Panel.General.Inner:SetJustifyV("TOP")
+AutomaticRoleCheck.Panel.General.Inner:SetText("AutomaticRoleCheck")
 
-AutomaticRoleCheck.Panel.Inner.EnabledButton:HookScript("OnClick", function()
-  AutomaticRoleCheck.Options.Enabled = AutomaticRoleCheck.Panel.Inner.EnabledButton:GetChecked()
+AutomaticRoleCheck.Panel.General.Inner.EnabledButton = CreateFrame("CheckButton", nil, AutomaticRoleCheck.Panel, "ChatConfigCheckButtonTemplate")
+AutomaticRoleCheck.Panel.General.Inner.EnabledButton:SetPoint("TOPLEFT", 10, -45)
+AutomaticRoleCheck.Panel.General.Inner.EnabledButton.Text:SetFontObject("GameFontHighlightSmall")
+AutomaticRoleCheck.Panel.General.Inner.EnabledButton.Text:SetPoint("LEFT", AutomaticRoleCheck.Panel.General.Inner.EnabledButton, "RIGHT", 0, 1)
+AutomaticRoleCheck.Panel.General.Inner.EnabledButton.Text:SetText("Enable AutomaticRoleCheck")
+AutomaticRoleCheck.Panel.General.Inner.EnabledButton.tooltip = "If the AutomaticRoleCheck addon is enabled."
+
+AutomaticRoleCheck.Panel.General.Inner.EnabledButton:HookScript("OnClick", function()
+  AutomaticRoleCheck.Options.Enabled = AutomaticRoleCheck.Panel.General.Inner.EnabledButton:GetChecked()
 end)
-AutomaticRoleCheck.Panel:HookScript("OnShow", function()
-  AutomaticRoleCheck.Panel.Inner.EnabledButton:SetChecked(AutomaticRoleCheck.Options.Enabled)
-end)
+
+
+function AutomaticRoleCheck.Panel.PopulatePanel()
+  AutomaticRoleCheck.Panel.General.Inner.EnabledButton:SetChecked(AutomaticRoleCheck.Options.Enabled)
+end
+
+AutomaticRoleCheck.Panel.General:HookScript("OnShow", AutomaticRoleCheck.Panel.PopulatePanel)
 AutomaticRoleCheck.Panel:HookScript("OnEvent", AutomaticRoleCheck.EventHandler)
 
 InterfaceOptions_AddCategory(AutomaticRoleCheck.Panel)

--- a/AutomaticRoleCheck_Panel.lua
+++ b/AutomaticRoleCheck_Panel.lua
@@ -22,12 +22,11 @@ AutomaticRoleCheck.Panel.General.Inner.EnabledButton:HookScript("OnClick", funct
   AutomaticRoleCheck.Options.Enabled = AutomaticRoleCheck.Panel.General.Inner.EnabledButton:GetChecked()
 end)
 
-
 function AutomaticRoleCheck.Panel.PopulatePanel()
   AutomaticRoleCheck.Panel.General.Inner.EnabledButton:SetChecked(AutomaticRoleCheck.Options.Enabled)
 end
 
-AutomaticRoleCheck.Panel.General:HookScript("OnShow", AutomaticRoleCheck.Panel.PopulatePanel)
+AutomaticRoleCheck.Panel:HookScript("OnShow", AutomaticRoleCheck.Panel.PopulatePanel)
 AutomaticRoleCheck.Panel:HookScript("OnEvent", AutomaticRoleCheck.EventHandler)
 
 InterfaceOptions_AddCategory(AutomaticRoleCheck.Panel)

--- a/AutomaticRoleCheck_Panel_Settings.lua
+++ b/AutomaticRoleCheck_Panel_Settings.lua
@@ -15,8 +15,8 @@ AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceButton.Text:SetPoint("LEFT", 
 AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceButton.Text:SetText("Disable once")
 AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceButton.tooltip = "If the addon is disabled once for the upcoming role check."
 
-AutomaticRoleCheck.Panel.Inner.EnabledButton:HookScript("OnClick", function()
-  if AutomaticRoleCheck.Panel.Inner.EnabledButton:GetChecked() then
+AutomaticRoleCheck.Panel.General.Inner.EnabledButton:HookScript("OnClick", function()
+  if AutomaticRoleCheck.Panel.General.Inner.EnabledButton:GetChecked() then
     AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceButton:Enable()
   else
     AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceButton:Disable()
@@ -25,9 +25,12 @@ end)
 AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceButton:HookScript("OnClick", function()
   AutomaticRoleCheck.Options.DisableOnce = AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceButton:GetChecked()
 end)
-AutomaticRoleCheck.Panel.Settings:HookScript("OnShow", function()
+
+function AutomaticRoleCheck.Panel.Settings.PopulatePanel()
   AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceButton:SetChecked(AutomaticRoleCheck.Options.DisableOnce)
-end)
+end
+
+AutomaticRoleCheck.Panel.Settings:HookScript("OnShow", AutomaticRoleCheck.Panel.Settings.PopulatePanel)
 AutomaticRoleCheck.Panel.Settings:HookScript("OnEvent", AutomaticRoleCheck.EventHandler)
 
 InterfaceOptions_AddCategory(AutomaticRoleCheck.Panel.Settings);


### PR DESCRIPTION
Fix: when going to the Settings panel before the parent "Automatic Role Check" panel in addon settings, no longer causes the latter's fields (the Enabled checkbox, in this case) to not update.

The following examples have both settings on (which in the "before" are correctly refreshed when going back to Settings and then to the parent panel).

Before:
![arc_before](https://github.com/jordinbrouwer/AutomaticRoleCheck/assets/115635920/93138c18-b656-4444-8325-c485e7c472d0)
After:
![arc_after](https://github.com/jordinbrouwer/AutomaticRoleCheck/assets/115635920/55fd91ea-69b7-4648-a176-69e0cfb18a2f)
