### PR TITLE
Implemented 'Disable Once on Login' feature/setting

### DIFF
--- a/AutomaticRoleCheck.lua
+++ b/AutomaticRoleCheck.lua
@@ -4,6 +4,7 @@ AutomaticRoleCheck.__index = AutomaticRoleCheck
 AutomaticRoleCheck.Defaults = {
   Enabled = true,
   DisableOnce = false,
+  DisableOnceOnLogin = false,
 }
 AutomaticRoleCheck.Accept = function(self)
   if AutomaticRoleCheck.Options.Enabled then
@@ -20,6 +21,9 @@ AutomaticRoleCheck.EventHandler = function(self, event, arg, ...)
       for k, v in pairs(AutomaticRoleCheck_Options) do
         AutomaticRoleCheck.Options[k] = v
       end
+      AutomaticRoleCheck.Options.DisableOnce = AutomaticRoleCheck.Options.DisableOnce and -- ?
+                                              AutomaticRoleCheck.Options.DisableOnce or -- then
+                                              AutomaticRoleCheck.Options.DisableOnceOnLogin -- else
     end
   elseif event == "PLAYER_LOGOUT" then
     AutomaticRoleCheck_Options = AutomaticRoleCheck.Options

--- a/AutomaticRoleCheck_Panel.lua
+++ b/AutomaticRoleCheck_Panel.lua
@@ -19,9 +19,12 @@ AutomaticRoleCheck.Panel.Inner.EnabledButton.tooltip = "If the AutomaticRoleChec
 AutomaticRoleCheck.Panel.Inner.EnabledButton:HookScript("OnClick", function()
   AutomaticRoleCheck.Options.Enabled = AutomaticRoleCheck.Panel.Inner.EnabledButton:GetChecked()
 end)
-AutomaticRoleCheck.Panel:HookScript("OnShow", function()
+
+function AutomaticRoleCheck.Panel.PopulatePanel()
   AutomaticRoleCheck.Panel.Inner.EnabledButton:SetChecked(AutomaticRoleCheck.Options.Enabled)
-end)
+end
+
+AutomaticRoleCheck.Panel:HookScript("OnShow", AutomaticRoleCheck.Panel.PopulatePanel)
 AutomaticRoleCheck.Panel:HookScript("OnEvent", AutomaticRoleCheck.EventHandler)
 
 InterfaceOptions_AddCategory(AutomaticRoleCheck.Panel)

--- a/AutomaticRoleCheck_Panel_Settings.lua
+++ b/AutomaticRoleCheck_Panel_Settings.lua
@@ -15,19 +15,35 @@ AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceButton.Text:SetPoint("LEFT", 
 AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceButton.Text:SetText("Disable once")
 AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceButton.tooltip = "If the addon is disabled once for the upcoming role check."
 
+AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceOnLoginButton = CreateFrame("CheckButton", nil, AutomaticRoleCheck.Panel.Settings, "ChatConfigCheckButtonTemplate")
+AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceOnLoginButton:SetPoint("TOPLEFT", 10, -75)
+AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceOnLoginButton.Text:SetFontObject("GameFontHighlightSmall")
+AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceOnLoginButton.Text:SetPoint("LEFT", AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceOnLoginButton, "RIGHT", 0, 1)
+AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceOnLoginButton.Text:SetText("Disable once on login")
+AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceOnLoginButton.tooltip = "If the addon is disabled once on login."
+
 AutomaticRoleCheck.Panel.Inner.EnabledButton:HookScript("OnClick", function()
   if AutomaticRoleCheck.Panel.Inner.EnabledButton:GetChecked() then
     AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceButton:Enable()
+    AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceOnLoginButton:Enable()
   else
     AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceButton:Disable()
+    AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceOnLoginButton:Disable()
   end
 end)
 AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceButton:HookScript("OnClick", function()
   AutomaticRoleCheck.Options.DisableOnce = AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceButton:GetChecked()
 end)
-AutomaticRoleCheck.Panel.Settings:HookScript("OnShow", function()
-  AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceButton:SetChecked(AutomaticRoleCheck.Options.DisableOnce)
+AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceOnLoginButton:HookScript("OnClick", function()
+  AutomaticRoleCheck.Options.DisableOnceOnLogin = AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceOnLoginButton:GetChecked()
 end)
+
+function AutomaticRoleCheck.Panel.Settings.PopulatePanel()
+  AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceButton:SetChecked(AutomaticRoleCheck.Options.DisableOnce)
+  AutomaticRoleCheck.Panel.Settings.Inner.DisableOnceOnLoginButton:SetChecked(AutomaticRoleCheck.Options.DisableOnceOnLogin)
+end
+
+AutomaticRoleCheck.Panel.Settings:HookScript("OnShow", AutomaticRoleCheck.Panel.Settings.PopulatePanel)
 AutomaticRoleCheck.Panel.Settings:HookScript("OnEvent", AutomaticRoleCheck.EventHandler)
 
 InterfaceOptions_AddCategory(AutomaticRoleCheck.Panel.Settings);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/jordinbrouwer/AutomaticRoleCheck/compare/1.10.0...master)
 
+### Added
+- Added a feature to disable first role check upon each login.
+
 ## [1.10.0 (2024-06-10)](https://github.com/jordinbrouwer/AutomaticRoleCheck/compare/1.9.0...1.10.0)
 
 ### Fixed
@@ -10,9 +13,6 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Bumped version due to new patch.
-
-### Added
-- Added a feature to disable first role check upon each login.
 
 ## [1.9.0 (2024-02-13)](https://github.com/jordinbrouwer/AutomaticRoleCheck/compare/1.8.0...1.9.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/jordinbrouwer/AutomaticRoleCheck/compare/1.9.0...master)
 
+### Added
+- Added a feature to disable first role check upon each login.
+
 ## [1.9.0 (2024-02-13)](https://github.com/jordinbrouwer/AutomaticRoleCheck/compare/1.8.0...1.9.0)
 
 ### Changed


### PR DESCRIPTION
Implemented 'Disable Once on Login' feature/setting, automatically enabling 'Disable Once' on login to allow for setting role/message for that session without having to manually disable once.

<img width="343" alt="disable_once_on_login" src="https://github.com/jordinbrouwer/AutomaticRoleCheck/assets/115635920/17b7adf1-0977-4ec2-b406-5695f11a4393">
